### PR TITLE
Altrecht in all casing and postcodes do not replace punctuation after…

### DIFF
--- a/deduce/annotate.py
+++ b/deduce/annotate.py
@@ -376,6 +376,15 @@ def annotate_residence(text):
     # Return the de-identified text
     return join_tokens(tokens_deid)
 
+def replace_altrecht_text(match: re.Match) -> str:
+    """
+    <INSTELLING Altrecht> (with Altrecht in any casing) followed by words that start with capital letters is annotated
+    as <INSTELLING Altrecht Those Words>, where Altrecht retains the original casing
+    :param match: the match object from a regular expression search
+    :return: the final string
+    """
+    return match.group(0)[:len(match.group(0)) - len(match.group(1)) - 1] + match.group(1) + '>'
+
 def annotate_institution(text):
     """ Annotate institutions """
 
@@ -411,8 +420,8 @@ def annotate_institution(text):
     text = join_tokens(tokens_deid)
 
     # Detect the word "Altrecht" followed by a capitalized word
-    text = re.sub("<INSTELLING altrecht>((\s[A-Z]{1}([\w]*))*)",
-                  "<INSTELLING altrecht" + "\\1".lower() + ">",
+    text = re.sub('<INSTELLING [aA][lL][tT][rR][eE][cC][hH][tT]>((\s[A-Z]([\w]*))*)',
+                  replace_altrecht_text,
                   text)
 
     # Return the text
@@ -464,7 +473,7 @@ def annotate_patientnumber(text):
 def annotate_postalcode(text):
     """ Annotate postal codes """
     text = re.sub("(((\d{4} [A-Z]{2})|(\d{4}[a-zA-Z]{2})))(?P<n>\W)(?![^<]*>)",
-                  "<LOCATIE \\1> ",
+                  "<LOCATIE \\1>\\5",
                   text)
 
     text = re.sub("<LOCATIE\s(\d{4}mg)>",

--- a/deduce/unittests/test_annotate.py
+++ b/deduce/unittests/test_annotate.py
@@ -108,5 +108,29 @@ class TestAnnotateMethods(unittest.TestCase):
         expected_text = 'Ik ben in <INSTELLING Altrecht> geweest'
         self.assertEqual(expected_text, annotated_institutions_text)
 
+    def test_skip_mg(self):
+        text = '<LOCATIE Hoofdstraat> is mooi. (br)Lithiumcarbonaat 1600mg. Nog een zin'
+        annotated_postcodes_text = annotate.annotate_postalcode(text)
+        self.assertEqual(text, annotated_postcodes_text)
+
+    def test_annotate_postcode(self):
+        text = 'Mijn postcode is 3500LX, toch?'
+        annotated_postcodes_text = annotate.annotate_postalcode(text)
+        expected_text = text.replace('3500LX', '<LOCATIE 3500LX>')
+        self.assertEqual(expected_text, annotated_postcodes_text)
+
+    def test_annotate_altrecht(self):
+        text = 'Opname bij xxx afgerond'
+        examples = [('altrecht lunetten', '<INSTELLING altrecht> lunetten'),
+                    ('altrecht Lunetten', '<INSTELLING altrecht Lunetten>'),
+                    ('Altrecht lunetten', '<INSTELLING Altrecht> lunetten'),
+                    ('Altrecht Lunetten', '<INSTELLING Altrecht Lunetten>'),
+                    ('Altrecht Willem Arntszhuis', '<INSTELLING Altrecht Willem Arntszhuis>'),
+                    ('Altrecht Lunetten ziekenhuis', '<INSTELLING Altrecht Lunetten> ziekenhuis'),
+                    ('ALtrecht Lunetten', '<INSTELLING ALtrecht Lunetten>')]
+        annotated = [annotate.annotate_institution(text.replace('xxx', el[0])) for el in examples]
+        expected = [text.replace('xxx', el[1]) for el in examples]
+        self.assertEqual(expected, annotated)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Two bug fixes:

1) <INSTELLING Altrecht> Lunetten should go to <INSTELLING Altrecht Lunetten>, and not <INSTELLING altrecht Lunetten>

2) "3600LX, toch?" should be come "<LOCATIE 3600LX>, toch?" and not "<LOCATIE 3600LX>  toch?"

Both are fixed, unit tests were created, and I tested that it didn't break anything in a sample of 3000 texts