### PR TITLE
initials should not get lost along the way

### DIFF
--- a/deduce/annotate.py
+++ b/deduce/annotate.py
@@ -274,12 +274,13 @@ def annotate_names_context(text):
         if interfix_condition:
             # Remove some already identified tokens, to prevent double tagging
             (_, previous_token_index_deid, _, _) = context(tokens_deid, len(tokens_deid))
+            deid_tokens_to_keep = tokens_deid[previous_token_index_deid:]
             tokens_deid = tokens_deid[:previous_token_index_deid]
             tokens_deid.append(
                 "<INTERFIXACHTERNAAM {}>".format(
-                    join_tokens(tokens[previous_token_index : next_token_index+1])
-                    )
+                    join_tokens(deid_tokens_to_keep + tokens[token_index:next_token_index + 1])
                 )
+            )
             token_index = next_token_index
             continue
 

--- a/deduce/unittests/test_annotate.py
+++ b/deduce/unittests/test_annotate.py
@@ -132,5 +132,12 @@ class TestAnnotateMethods(unittest.TestCase):
         expected = [text.replace('xxx', el[1]) for el in examples]
         self.assertEqual(expected, annotated)
 
+    def test_annotate_context_keep_initial(self):
+        text = 'Mijn naam is M <ACHTERNAAMONBEKEND Smid> de Vries'
+        annotated_context_names = annotate.annotate_names_context(text)
+        expected = 'Mijn naam is <INTERFIXACHTERNAAM <INITIAAL M <ACHTERNAAMONBEKEND Smid>> de Vries>'
+        self.assertEqual(expected, annotated_context_names)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
annotate_names_context was getting rid of some tokens incorrectly