### PR TITLE
Update age regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - by default, deduce now recognizes all 7+ digit numbers as identifiers
 - improved regular expressions for e-mail address and url matching
 - separate tags for emails and urls
+- improved regular expression for age matching
 
 ### Removed
 - a separate patient identifier tag, now superseded by a generic tag

--- a/config.json
+++ b/config.json
@@ -263,9 +263,9 @@
             "annotator_type": "regexp",
             "group": "ages",
             "args": {
-                "regexp_pattern": "(\\d{1,3})([ -](jarige|jarig|jaar))",
+                "regexp_pattern": "(?i)(?<!(policontrole) )(?<!(gedurende) )(?<!(controle|onder de) )(?<!(sinds|om de|in de) )(?<!(over|elke) )(?<!(nog) )(?<!(na|op|al) )(?<!(<) )(?<!\\d-)(?<!\\d\\d-)(?<!\\d)(?<!\\d[,.])((((\\d-|\\d\\d-))?(\\d[,\\.]\\d|\\d{1,3}))([ -](jarige|jarig|jaar)))(?!\\w)(?! (geleden|na|aanwezig|getrouwd|gestopt|gerookt|gebruikt|gestaakt))",
                 "tag": "leeftijd",
-                "capturing_group": 1
+                "capturing_group": 10
             }
         },
         "email": {

--- a/tests/unit/test_deduce_processors.py
+++ b/tests/unit/test_deduce_processors.py
@@ -183,7 +183,7 @@ class TestRegexpAnnotators:
         assert annotations == expected_annotations
 
     def test_annotate_age(self):
-        text = "14 jaar oud, 14-jarige, 14 jarig"
+        text = "14 jaar oud, 14-jarige, 14 jarig, sinds 14 jaar, 14 jaar geleden"
 
         annotator = get_annotator("age", group="ages")
         expected_annotations = {


### PR DESCRIPTION
* Include age ranges, like `op 11-12 jarige leeftijd herhalen`
* Include some negative lookahead/lookbehind, like `sinds 1 jaar` or `1 jaar geleden`