### PR TITLE
Update tokenizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - tokenizer logic: 
-  - a token is now a sequence of alpha characters, a sequence of numeric characters, a single newline, or a single special character. 
+  - a token is now a sequence of alphanumeric characters, a single newline, or a single special character. 
   - whitespaces are no longer considered tokens
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## (unreleased)
+
+### Changed
+- tokenizer logic: 
+  - a token is now a sequence of alpha characters, a sequence of numeric characters, a single newline, or a single special character. 
+  - whitespaces are no longer considered tokens
+
+
 ## 2.1.0 (2023-08-07)
 
 ### Added

--- a/deduce/deduce.py
+++ b/deduce/deduce.py
@@ -67,7 +67,6 @@ class Deduce(dd.DocDeid):
         """Initializes tokenizers."""
 
         merge_terms = dd.ds.LookupSet()
-        merge_terms.add_items_from_iterable(["A1", "A2", "A3", "A4", "\n", "\r", "\t"])
         merge_terms += self.lookup_sets["interfixes"]
         merge_terms += self.lookup_sets["prefixes"]
 

--- a/deduce/pattern/name.py
+++ b/deduce/pattern/name.py
@@ -16,16 +16,16 @@ class PrefixWithNamePattern(TokenPatternWithLookup):
     """Matches prefixes followed by a titlecase word."""
 
     def token_precondition(self, token: dd.Token) -> bool:
-        return token.next() is not None
+        return token.next_alpha() is not None
 
     def match(self, token: dd.Token, metadata: dd.MetaData) -> Optional[tuple[dd.Token, dd.Token]]:
         if (
             token.text.lower() in self._lookup_sets["prefixes"]
-            and token.next().text[0].isupper()
-            and token.next().text not in self._lookup_sets["whitelist"]
+            and token.next_alpha().text[0].isupper()
+            and token.next_alpha().text not in self._lookup_sets["whitelist"]
         ):
 
-            return token, token.next()
+            return token, token.next_alpha()
 
         return None
 
@@ -34,16 +34,16 @@ class InterfixWithNamePattern(TokenPatternWithLookup):
     """Matches interfixes followed by an interfix surname."""
 
     def token_precondition(self, token: dd.Token) -> bool:
-        return token.next() is not None
+        return token.next_alpha() is not None
 
     def match(self, token: dd.Token, metadata: dd.MetaData) -> Optional[tuple[dd.Token, dd.Token]]:
         if (
             token.text.lower() in self._lookup_sets["interfixes"]
-            and token.next().text in self._lookup_sets["interfix_surnames"]
-            and token.next().text not in self._lookup_sets["whitelist"]
+            and token.next_alpha().text in self._lookup_sets["interfix_surnames"]
+            and token.next_alpha().text not in self._lookup_sets["whitelist"]
         ):
 
-            return token, token.next()
+            return token, token.next_alpha()
 
         return None
 
@@ -52,18 +52,18 @@ class InitialWithCapitalPattern(TokenPatternWithLookup):
     """Matches an initial followed by an titlecase word with at least 3 characters."""
 
     def token_precondition(self, token: dd.Token) -> bool:
-        return token.next() is not None
+        return token.next_alpha() is not None
 
     def match(self, token: dd.Token, metadata: dd.MetaData) -> Optional[tuple[dd.Token, dd.Token]]:
         if (
             token.text[0].isupper()
             and len(token) == 1
-            and len(token.next()) > 3
-            and token.next().text[0].isupper()
-            and token.next().text not in self._lookup_sets["whitelist"]
+            and len(token.next_alpha()) > 3
+            and token.next_alpha().text[0].isupper()
+            and token.next_alpha().text not in self._lookup_sets["whitelist"]
         ):
 
-            return token, token.next()
+            return token, token.next_alpha()
 
         return None
 
@@ -72,17 +72,17 @@ class InitiaalInterfixCapitalPattern(TokenPatternWithLookup):
     """Matches an initial, followed by an interfix, followed by a titlecase word."""
 
     def token_precondition(self, token: dd.Token) -> bool:
-        return (token.previous() is not None) and (token.next() is not None)
+        return (token.previous_alpha() is not None) and (token.next_alpha() is not None)
 
     def match(self, token: dd.Token, metadata: dd.MetaData) -> Optional[tuple[dd.Token, dd.Token]]:
         if (
-            token.previous().text[0].isupper()
-            and len(token.previous()) == 1
-            and token.next().text[0].isupper()
+            token.previous_alpha().text[0].isupper()
+            and len(token.previous_alpha()) == 1
+            and token.next_alpha().text[0].isupper()
             and token.text in self._lookup_sets["interfixes"]
         ):
 
-            return token.previous(), token.next()
+            return token.previous_alpha(), token.next_alpha()
 
         return None
 

--- a/deduce/pattern/name_context.py
+++ b/deduce/pattern/name_context.py
@@ -67,7 +67,8 @@ class InitialsContextPattern(AnnotationContextPatternWithLookupSet):
 
     def match(self, annotation: dd.Annotation) -> Optional[tuple[dd.Token, dd.Token]]:
         previous_token_is_initial = (
-            len(annotation.start_token.previous_alpha().text) == 1 and annotation.start_token.previous_alpha().text[0].isupper()
+            len(annotation.start_token.previous_alpha().text) == 1
+            and annotation.start_token.previous_alpha().text[0].isupper()
         )
 
         previous_token_is_name = (

--- a/deduce/pattern/name_context.py
+++ b/deduce/pattern/name_context.py
@@ -45,16 +45,16 @@ class InterfixContextPattern(AnnotationContextPatternWithLookupSet):
     """Matches an annotated name or initial, followed by an interfix, followed by a titlecase word."""
 
     def annotation_precondition(self, annotation: dd.Annotation) -> bool:
-        return annotation.end_token.next() is not None and annotation.end_token.next(2) is not None
+        return annotation.end_token.next_alpha() is not None and annotation.end_token.next_alpha(2) is not None
 
     def match(self, annotation: dd.Annotation) -> Optional[tuple[dd.Token, dd.Token]]:
         if (
             utils.any_in_text(["initia", "naam"], annotation.tag)
-            and annotation.end_token.next().text in self._lookup_sets["interfixes"]
-            and annotation.end_token.next(2).text[0].isupper()
+            and annotation.end_token.next_alpha().text in self._lookup_sets["interfixes"]
+            and annotation.end_token.next_alpha(2).text[0].isupper()
         ):
 
-            return annotation.start_token, annotation.end_token.next(2)
+            return annotation.start_token, annotation.end_token.next_alpha(2)
 
         return None
 
@@ -63,25 +63,25 @@ class InitialsContextPattern(AnnotationContextPatternWithLookupSet):
     """Matches an annotated achternaam, interfix or initial, preceded by either an initial or a titlecase word."""
 
     def annotation_precondition(self, annotation: dd.Annotation) -> bool:
-        return annotation.start_token.previous() is not None
+        return annotation.start_token.previous_alpha() is not None
 
     def match(self, annotation: dd.Annotation) -> Optional[tuple[dd.Token, dd.Token]]:
         previous_token_is_initial = (
-            len(annotation.start_token.previous().text) == 1 and annotation.start_token.previous().text[0].isupper()
+            len(annotation.start_token.previous_alpha().text) == 1 and annotation.start_token.previous_alpha().text[0].isupper()
         )
 
         previous_token_is_name = (
-            annotation.start_token.previous().text != ""
-            and annotation.start_token.previous().text[0].isupper()
-            and annotation.start_token.previous().text not in self._lookup_sets["whitelist"]
-            and annotation.start_token.previous().text.lower() not in self._lookup_sets["prefixes"]
+            annotation.start_token.previous_alpha().text != ""
+            and annotation.start_token.previous_alpha().text[0].isupper()
+            and annotation.start_token.previous_alpha().text not in self._lookup_sets["whitelist"]
+            and annotation.start_token.previous_alpha().text.lower() not in self._lookup_sets["prefixes"]
         )
 
         if utils.any_in_text(["achternaam", "interfix", "initia"], annotation.tag) and (
             previous_token_is_initial or previous_token_is_name
         ):
 
-            return annotation.start_token.previous(), annotation.end_token
+            return annotation.start_token.previous_alpha(), annotation.end_token
 
         return None
 
@@ -91,17 +91,17 @@ class InitialNameContextPattern(AnnotationContextPatternWithLookupSet):
     characters."""
 
     def annotation_precondition(self, annotation: dd.Annotation) -> bool:
-        return annotation.end_token.next() is not None
+        return annotation.end_token.next_alpha() is not None
 
     def match(self, annotation: dd.Annotation) -> Optional[tuple[dd.Token, dd.Token]]:
         if (
             utils.any_in_text(["initia", "voornaam", "roepnaam", "prefix"], annotation.tag)
-            and len(annotation.end_token.next().text) > 3
-            and annotation.end_token.next().text[0].isupper()
-            and annotation.end_token.next().text not in self._lookup_sets["whitelist"]
+            and len(annotation.end_token.next_alpha().text) > 3
+            and annotation.end_token.next_alpha().text[0].isupper()
+            and annotation.end_token.next_alpha().text not in self._lookup_sets["whitelist"]
         ):
 
-            return annotation.start_token, annotation.end_token.next()
+            return annotation.start_token, annotation.end_token.next_alpha()
 
         return None
 
@@ -110,11 +110,11 @@ class NexusContextPattern(AnnotationContextPattern):
     """Matches any annotated name, followed by "en", followed by a titlecase word."""
 
     def annotation_precondition(self, annotation: dd.Annotation) -> bool:
-        return annotation.end_token.next() is not None and annotation.end_token.next(2) is not None
+        return annotation.end_token.next_alpha() is not None and annotation.end_token.next_alpha(2) is not None
 
     def match(self, annotation: dd.Annotation) -> Optional[tuple[dd.Token, dd.Token]]:
-        if annotation.end_token.next().text == "en" and annotation.end_token.next(2).text[0].isupper():
+        if annotation.end_token.next_alpha().text == "en" and annotation.end_token.next_alpha(2).text[0].isupper():
 
-            return annotation.start_token, annotation.end_token.next(2)
+            return annotation.start_token, annotation.end_token.next_alpha(2)
 
         return None

--- a/deduce/pattern/name_patient.py
+++ b/deduce/pattern/name_patient.py
@@ -42,7 +42,7 @@ class PersonInitialFromNamePattern(dd.TokenPattern):
 
             if str_match(token.text, first_name[0]):
 
-                next_token = token.next()
+                next_token = token.next_alpha()
 
                 if (next_token is not None) and str_match(next_token.text, "."):
                     return token, next_token
@@ -100,8 +100,8 @@ class PersonSurnamePattern(dd.TokenPattern):
 
             match_end_token = token
 
-            surname_token = surname_token.next()
-            token = token.next()
+            surname_token = surname_token.next_alpha()
+            token = token.next_alpha()
 
             if surname_token is None:
                 return start_token, match_end_token  # end of pattern

--- a/deduce/pattern/name_patient.py
+++ b/deduce/pattern/name_patient.py
@@ -42,7 +42,7 @@ class PersonInitialFromNamePattern(dd.TokenPattern):
 
             if str_match(token.text, first_name[0]):
 
-                next_token = token.next_alpha()
+                next_token = token.next()
 
                 if (next_token is not None) and str_match(next_token.text, "."):
                     return token, next_token

--- a/deduce/tokenizer.py
+++ b/deduce/tokenizer.py
@@ -18,7 +18,7 @@ class DeduceToken(dd.tokenize.Token):
             if next_token is None:
                 return None
 
-            if next_token.text in {')', '>', '\n', '\r', '\t'}:
+            if next_token.text in {")", ">", "\n", "\r", "\t"}:
                 return None
 
             if next_token.text[0].isalpha():
@@ -40,7 +40,7 @@ class DeduceToken(dd.tokenize.Token):
             if previous_token is None:
                 return None
 
-            if previous_token.text in {'(', '<', '\n', '\r', '\t'}:
+            if previous_token.text in {"(", "<", "\n", "\r", "\t"}:
                 return None
 
             if previous_token.text[0].isalpha():

--- a/deduce/tokenizer.py
+++ b/deduce/tokenizer.py
@@ -4,13 +4,13 @@ from typing import Iterable, Optional
 import docdeid as dd
 import regex
 
-TOKENIZER_PATTERN = regex.compile(r"[a-z]+|\d+|[\n\r]|.(?<! )", flags=re.I | re.M)
+TOKENIZER_PATTERN = regex.compile(r"\w+|[\n\r\t]|.(?<! )", flags=re.I | re.M)
 
 
 class DeduceTokenizer(dd.tokenize.Tokenizer):
     """
-    Tokenizes text, where a token is any sequence of alpha characters (case insensitive), any sequence of numeric
-    characters, a single newline character, or a single special character. It does not include whitespaces as tokens.
+    Tokenizes text, where a token is any sequence of alphanumeric characters (case insensitive), a single
+    newline/tab character, or a single special character. It does not include whitespaces as tokens.
 
     Arguments:
         merge_terms: An iterable of strings that should not be split (i.e. always returned as tokens).

--- a/deduce/tokenizer.py
+++ b/deduce/tokenizer.py
@@ -8,7 +8,10 @@ TOKENIZER_PATTERN = regex.compile(r"\w+|[\n\r\t]|.(?<! )", flags=re.I | re.M)
 
 
 class DeduceToken(dd.tokenize.Token):
+    """Deduce token, which implements next alpha logic."""
+
     def next_alpha(self, num: int = 1) -> Optional[dd.tokenize.Token]:
+        """Find the next alpha token, if any."""
 
         cntr = 0
         next_token = self.next()
@@ -31,6 +34,7 @@ class DeduceToken(dd.tokenize.Token):
             next_token = next_token.next()
 
     def previous_alpha(self, num: int = 1) -> Optional[dd.tokenize.Token]:
+        """Find the previous alpha token, if any."""
 
         cntr = 0
         previous_token = self.previous()

--- a/deduce/tokenizer.py
+++ b/deduce/tokenizer.py
@@ -22,14 +22,14 @@ class DeduceToken(dd.tokenize.Token):
             if next_token.text in {')', '>', '\n', '\r', '\t'}:
                 return None
 
-            next_token = next_token.next()
-
             if next_token.text.isalpha():
 
                 cntr += 1
 
                 if cntr == num:
                     return next_token
+
+            next_token = next_token.next()
 
     def previous_alpha(self, num: int = 1) -> Optional[dd.tokenize.Token]:
 
@@ -44,14 +44,16 @@ class DeduceToken(dd.tokenize.Token):
             if previous_token.text in {'(', '<', '\n', '\r', '\t'}:
                 return None
 
-            previous_token = previous_token.previous()
-
             if previous_token.text.isalpha():
 
                 cntr += 1
 
                 if cntr == num:
                     return previous_token
+
+            previous_token = previous_token.previous()
+
+
 
 
 class DeduceTokenizer(dd.tokenize.Tokenizer):

--- a/deduce/tokenizer.py
+++ b/deduce/tokenizer.py
@@ -8,7 +8,6 @@ TOKENIZER_PATTERN = regex.compile(r"\w+|[\n\r\t]|.(?<! )", flags=re.I | re.M)
 
 
 class DeduceToken(dd.tokenize.Token):
-
     def next_alpha(self, num: int = 1) -> Optional[dd.tokenize.Token]:
 
         cntr = 0
@@ -22,7 +21,7 @@ class DeduceToken(dd.tokenize.Token):
             if next_token.text in {')', '>', '\n', '\r', '\t'}:
                 return None
 
-            if next_token.text.isalpha():
+            if next_token.text[0].isalpha():
 
                 cntr += 1
 
@@ -44,7 +43,7 @@ class DeduceToken(dd.tokenize.Token):
             if previous_token.text in {'(', '<', '\n', '\r', '\t'}:
                 return None
 
-            if previous_token.text.isalpha():
+            if previous_token.text[0].isalpha():
 
                 cntr += 1
 
@@ -54,12 +53,10 @@ class DeduceToken(dd.tokenize.Token):
             previous_token = previous_token.previous()
 
 
-
-
 class DeduceTokenizer(dd.tokenize.Tokenizer):
     """
-    Tokenizes text, where a token is any sequence of alphanumeric characters (case insensitive), a single
-    newline/tab character, or a single special character. It does not include whitespaces as tokens.
+    Tokenizes text, where a token is any sequence of alphanumeric characters (case insensitive), a single newline/tab
+    character, or a single special character. It does not include whitespaces as tokens.
 
     Arguments:
         merge_terms: An iterable of strings that should not be split (i.e. always returned as tokens).

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,8 @@
 import docdeid as dd
 
+from deduce.tokenizer import DeduceToken
 
-def link_tokens(tokens: list[dd.Token]):
+def link_tokens(tokens: list[DeduceToken]):
     for token, next_token in zip(tokens, tokens[1:]):
         token.set_next_token(next_token)
         next_token.set_previous_token(token)
@@ -9,7 +10,7 @@ def link_tokens(tokens: list[dd.Token]):
     return tokens
 
 
-def linked_tokens(tokens: list[str]) -> list[dd.Token]:
-    tokens = [dd.Token(x, 0, len(x)) for x in tokens]
+def linked_tokens(tokens: list[str]) -> list[DeduceToken]:
+    tokens = [DeduceToken(x, 0, len(x)) for x in tokens]
 
     return link_tokens(tokens)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,6 +2,7 @@ import docdeid as dd
 
 from deduce.tokenizer import DeduceToken
 
+
 def link_tokens(tokens: list[DeduceToken]):
     for token, next_token in zip(tokens, tokens[1:]):
         token.set_next_token(next_token)

--- a/tests/unit/tokenize/test_tokenizer.py
+++ b/tests/unit/tokenize/test_tokenizer.py
@@ -1,22 +1,22 @@
 import docdeid as dd
 import pytest
 
-from deduce.tokenizer import DeduceTokenizer
+from deduce.tokenizer import DeduceTokenizer, DeduceToken
 
 
 @pytest.fixture
 def tokens():
     return [
-        dd.tokenize.Token(text="Patient", start_char=0, end_char=7),
-        dd.tokenize.Token(text="was", start_char=8, end_char=11),
-        dd.tokenize.Token(text="eerder", start_char=12, end_char=18),
-        dd.tokenize.Token(text="opgenomen", start_char=19, end_char=28),
-        dd.tokenize.Token(text="(", start_char=29, end_char=30),
-        dd.tokenize.Token(text="vorig", start_char=30, end_char=35),
-        dd.tokenize.Token(text="jaar", start_char=36, end_char=40),
-        dd.tokenize.Token(text=")", start_char=40, end_char=41),
-        dd.tokenize.Token(text="alhier", start_char=42, end_char=48),
-        dd.tokenize.Token(text=".", start_char=48, end_char=49),
+        DeduceToken(text="Patient", start_char=0, end_char=7),
+        DeduceToken(text="was", start_char=8, end_char=11),
+        DeduceToken(text="eerder", start_char=12, end_char=18),
+        DeduceToken(text="opgenomen", start_char=19, end_char=28),
+        DeduceToken(text="(", start_char=29, end_char=30),
+        DeduceToken(text="vorig", start_char=30, end_char=35),
+        DeduceToken(text="jaar", start_char=36, end_char=40),
+        DeduceToken(text=")", start_char=40, end_char=41),
+        DeduceToken(text="alhier", start_char=42, end_char=48),
+        DeduceToken(text=".", start_char=48, end_char=49),
     ]
 
 
@@ -25,10 +25,10 @@ class TestTokenizer:
         tokenizer = DeduceTokenizer()
         text = "Pieter van der Zee"
         expected_tokens = [
-            dd.tokenize.Token(text="Pieter", start_char=0, end_char=6),
-            dd.tokenize.Token(text="van", start_char=7, end_char=10),
-            dd.tokenize.Token(text="der", start_char=11, end_char=14),
-            dd.tokenize.Token(text="Zee", start_char=15, end_char=18),
+            DeduceToken(text="Pieter", start_char=0, end_char=6),
+            DeduceToken(text="van", start_char=7, end_char=10),
+            DeduceToken(text="der", start_char=11, end_char=14),
+            DeduceToken(text="Zee", start_char=15, end_char=18),
         ]
 
         assert tokenizer._split_text(text=text) == expected_tokens
@@ -38,11 +38,11 @@ class TestTokenizer:
         text = "prematuur (<p3)"
 
         expected_tokens = [
-            dd.tokenize.Token(text="prematuur", start_char=0, end_char=9),
-            dd.tokenize.Token(text="(", start_char=10, end_char=11),
-            dd.tokenize.Token(text="<", start_char=11, end_char=12),
-            dd.tokenize.Token(text="p3", start_char=12, end_char=14),
-            dd.tokenize.Token(text=")", start_char=14, end_char=15),
+            DeduceToken(text="prematuur", start_char=0, end_char=9),
+            DeduceToken(text="(", start_char=10, end_char=11),
+            DeduceToken(text="<", start_char=11, end_char=12),
+            DeduceToken(text="p3", start_char=12, end_char=14),
+            DeduceToken(text=")", start_char=14, end_char=15),
         ]
 
         assert tokenizer._split_text(text=text) == expected_tokens
@@ -52,13 +52,13 @@ class TestTokenizer:
         text = "regel 1 \n gevolgd door regel 2"
 
         expected_tokens = [
-            dd.tokenize.Token(text="regel", start_char=0, end_char=5),
-            dd.tokenize.Token(text="1", start_char=6, end_char=7),
-            dd.tokenize.Token(text="\n", start_char=8, end_char=9),
-            dd.tokenize.Token(text="gevolgd", start_char=10, end_char=17),
-            dd.tokenize.Token(text="door", start_char=18, end_char=22),
-            dd.tokenize.Token(text="regel", start_char=23, end_char=28),
-            dd.tokenize.Token(text="2", start_char=29, end_char=30),
+            DeduceToken(text="regel", start_char=0, end_char=5),
+            DeduceToken(text="1", start_char=6, end_char=7),
+            DeduceToken(text="\n", start_char=8, end_char=9),
+            DeduceToken(text="gevolgd", start_char=10, end_char=17),
+            DeduceToken(text="door", start_char=18, end_char=22),
+            DeduceToken(text="regel", start_char=23, end_char=28),
+            DeduceToken(text="2", start_char=29, end_char=30),
         ]
 
         assert tokenizer._split_text(text=text) == expected_tokens
@@ -66,7 +66,7 @@ class TestTokenizer:
     def test_join_tokens(self, tokens):
         text = "Patient was eerder opgenomen"
         joined_token = DeduceTokenizer()._join_tokens(text, tokens[0:4])
-        expected_token = dd.tokenize.Token(text=text, start_char=0, end_char=28)
+        expected_token = DeduceToken(text=text, start_char=0, end_char=28)
 
         assert joined_token == expected_token
 
@@ -74,9 +74,9 @@ class TestTokenizer:
         tokenizer = DeduceTokenizer(merge_terms=["van der"])
         text = "Pieter van der Zee"
         expected_tokens = [
-            dd.tokenize.Token(text="Pieter", start_char=0, end_char=6),
-            dd.tokenize.Token(text="van der", start_char=7, end_char=14),
-            dd.tokenize.Token(text="Zee", start_char=15, end_char=18),
+            DeduceToken(text="Pieter", start_char=0, end_char=6),
+            DeduceToken(text="van der", start_char=7, end_char=14),
+            DeduceToken(text="Zee", start_char=15, end_char=18),
         ]
 
         assert tokenizer._split_text(text=text) == expected_tokens

--- a/tests/unit/tokenize/test_tokenizer.py
+++ b/tests/unit/tokenize/test_tokenizer.py
@@ -1,7 +1,7 @@
 import docdeid as dd
 import pytest
 
-from deduce.tokenizer import DeduceTokenizer, DeduceToken
+from deduce.tokenizer import DeduceToken, DeduceTokenizer
 
 
 @pytest.fixture

--- a/tests/unit/tokenize/test_tokenizer.py
+++ b/tests/unit/tokenize/test_tokenizer.py
@@ -7,76 +7,77 @@ from deduce.tokenizer import DeduceTokenizer
 @pytest.fixture
 def tokens():
     return [
-        dd.Token(text="Patient", start_char=0, end_char=7),
-        dd.Token(text=" ", start_char=7, end_char=8),
-        dd.Token(text="was", start_char=8, end_char=11),
-        dd.Token(text=" ", start_char=11, end_char=12),
-        dd.Token(text="eerder", start_char=12, end_char=18),
-        dd.Token(text=" ", start_char=18, end_char=19),
-        dd.Token(text="opgenomen", start_char=19, end_char=28),
-        dd.Token(text=" ", start_char=28, end_char=29),
-        dd.Token(text="(", start_char=29, end_char=30),
-        dd.Token(text="vorig", start_char=30, end_char=35),
-        dd.Token(text=" ", start_char=35, end_char=36),
-        dd.Token(text="jaar", start_char=36, end_char=40),
-        dd.Token(text=")", start_char=40, end_char=41),
-        dd.Token(text=" ", start_char=41, end_char=42),
-        dd.Token(text="alhier", start_char=42, end_char=48),
-        dd.Token(text=".", start_char=48, end_char=49),
+        dd.tokenize.Token(text="Patient", start_char=0, end_char=7),
+        dd.tokenize.Token(text="was", start_char=8, end_char=11),
+        dd.tokenize.Token(text="eerder", start_char=12, end_char=18),
+        dd.tokenize.Token(text="opgenomen", start_char=19, end_char=28),
+        dd.tokenize.Token(text="(", start_char=29, end_char=30),
+        dd.tokenize.Token(text="vorig", start_char=30, end_char=35),
+        dd.tokenize.Token(text="jaar", start_char=36, end_char=40),
+        dd.tokenize.Token(text=")", start_char=40, end_char=41),
+        dd.tokenize.Token(text="alhier", start_char=42, end_char=48),
+        dd.tokenize.Token(text=".", start_char=48, end_char=49),
     ]
 
 
 class TestTokenizer:
-    def test_split_text_no_merge(self):
+    def test_split_alpha(self):
         tokenizer = DeduceTokenizer()
         text = "Pieter van der Zee"
         expected_tokens = [
-            dd.Token(text="Pieter", start_char=0, end_char=6),
-            dd.Token(text=" ", start_char=6, end_char=7),
-            dd.Token(text="van", start_char=7, end_char=10),
-            dd.Token(text=" ", start_char=10, end_char=11),
-            dd.Token(text="der", start_char=11, end_char=14),
-            dd.Token(text=" ", start_char=14, end_char=15),
-            dd.Token(text="Zee", start_char=15, end_char=18),
+            dd.tokenize.Token(text="Pieter", start_char=0, end_char=6),
+            dd.tokenize.Token(text="van", start_char=7, end_char=10),
+            dd.tokenize.Token(text="der", start_char=11, end_char=14),
+            dd.tokenize.Token(text="Zee", start_char=15, end_char=18),
         ]
 
         assert tokenizer._split_text(text=text) == expected_tokens
+
+    def test_split_nonalpha(self):
+        tokenizer = DeduceTokenizer()
+        text = "prematuur (<p3)"
+
+        expected_tokens = [
+            dd.tokenize.Token(text="prematuur", start_char=0, end_char=9),
+            dd.tokenize.Token(text="(", start_char=10, end_char=11),
+            dd.tokenize.Token(text="<", start_char=11, end_char=12),
+            dd.tokenize.Token(text="p", start_char=12, end_char=13),
+            dd.tokenize.Token(text="3", start_char=13, end_char=14),
+            dd.tokenize.Token(text=")", start_char=14, end_char=15),
+        ]
+
+        assert tokenizer._split_text(text=text) == expected_tokens
+
+    def test_split_newline(self):
+        tokenizer = DeduceTokenizer()
+        text = "regel 1 \n gevolgd door regel 2"
+
+        expected_tokens = [
+            dd.tokenize.Token(text="regel", start_char=0, end_char=5),
+            dd.tokenize.Token(text="1", start_char=6, end_char=7),
+            dd.tokenize.Token(text="\n", start_char=8, end_char=9),
+            dd.tokenize.Token(text="gevolgd", start_char=10, end_char=17),
+            dd.tokenize.Token(text="door", start_char=18, end_char=22),
+            dd.tokenize.Token(text="regel", start_char=23, end_char=28),
+            dd.tokenize.Token(text="2", start_char=29, end_char=30),
+        ]
+
+        assert tokenizer._split_text(text=text) == expected_tokens
+
+    def test_join_tokens(self, tokens):
+        text = "Patient was eerder opgenomen"
+        joined_token = DeduceTokenizer()._join_tokens(text, tokens[0:4])
+        expected_token = dd.tokenize.Token(text=text, start_char=0, end_char=28)
+
+        assert joined_token == expected_token
 
     def test_split_with_merge(self):
         tokenizer = DeduceTokenizer(merge_terms=["van der"])
         text = "Pieter van der Zee"
         expected_tokens = [
-            dd.Token(text="Pieter", start_char=0, end_char=6),
-            dd.Token(text=" ", start_char=6, end_char=7),
-            dd.Token(text="van der", start_char=7, end_char=14),
-            dd.Token(text=" ", start_char=14, end_char=15),
-            dd.Token(text="Zee", start_char=15, end_char=18),
+            dd.tokenize.Token(text="Pieter", start_char=0, end_char=6),
+            dd.tokenize.Token(text="van der", start_char=7, end_char=14),
+            dd.tokenize.Token(text="Zee", start_char=15, end_char=18),
         ]
 
         assert tokenizer._split_text(text=text) == expected_tokens
-
-    def test_next_token(self, tokens):
-        tokenizer = DeduceTokenizer()
-
-        assert tokenizer._next_token(0, tokens) is tokens[2]
-        assert tokenizer._next_token(6, tokens) is tokens[9]
-        assert tokenizer._next_token(7, tokens) is tokens[9]
-        assert tokenizer._next_token(8, tokens) is tokens[9]
-        assert tokenizer._next_token(11, tokens) is None
-        assert tokenizer._next_token(14, tokens) is None
-        assert tokenizer._next_token(15, tokens) is None
-
-    def test_previous_token(self, tokens):
-        tokenizer = DeduceTokenizer()
-        assert tokenizer._previous_token(0, tokens) is None
-        assert tokenizer._previous_token(1, tokens) == tokens[0]
-        assert tokenizer._previous_token(2, tokens) == tokens[0]
-        assert tokenizer._previous_token(7, tokens) == tokens[6]
-        assert tokenizer._previous_token(9, tokens) is None
-        assert tokenizer._previous_token(10, tokens) is tokens[9]
-
-    def test_join_tokens(self, tokens):
-        joined_token = DeduceTokenizer()._join_tokens(tokens[0:7])
-        expected_token = dd.Token(text="Patient was eerder opgenomen", start_char=0, end_char=28)
-
-        assert joined_token == expected_token

--- a/tests/unit/tokenize/test_tokenizer.py
+++ b/tests/unit/tokenize/test_tokenizer.py
@@ -41,8 +41,7 @@ class TestTokenizer:
             dd.tokenize.Token(text="prematuur", start_char=0, end_char=9),
             dd.tokenize.Token(text="(", start_char=10, end_char=11),
             dd.tokenize.Token(text="<", start_char=11, end_char=12),
-            dd.tokenize.Token(text="p", start_char=12, end_char=13),
-            dd.tokenize.Token(text="3", start_char=13, end_char=14),
+            dd.tokenize.Token(text="p3", start_char=12, end_char=14),
             dd.tokenize.Token(text=")", start_char=14, end_char=15),
         ]
 


### PR DESCRIPTION
- tokenizer logic: 
  - a token is now a sequence of alphanumeric characters, a single newline, or a single special character 
  - whitespaces are no longer considered tokens
  - moved previous/next logic (only alpha) to token subclass, so other annotators are not affected 