### PR TITLE
Parameterize cache dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## (unreleased)
+## 3.0.3 (2023-07-16)
+
+### Added
+
+- A cache_path option, to define the path for saving/loading the lookup structure cache. You should use this if your install directory is not writable.
 
 ### Removed
+
 - the `config_file` keyword, now replaced by `config` which accepts both filenames and dicts
 - old lookup list names, e.g. `prefixes` now replaced by `prefix`
 - annotator types `custom`, `regexp`, `token_pattern`, `dd_token_pattern` and `annotation_context`, all replaced by setting class directly as `annotator_type` 

--- a/deduce/lookup_structs.py
+++ b/deduce/lookup_structs.py
@@ -201,7 +201,7 @@ def cache_lookup_structs(
         pickle.dump(cache, file)
 
 
-def get_lookup_structs(
+def get_lookup_structs(  # pylint: disable=R0913
     lookup_path: Path,
     cache_path: Path,
     tokenizer: Tokenizer,

--- a/deduce/lookup_structs.py
+++ b/deduce/lookup_structs.py
@@ -67,7 +67,6 @@ def load_raw_itemset(path: Path) -> set[str]:
     sub_list_dirs = list(path.glob("lst_*"))
 
     if items is None:
-
         if len(sub_list_dirs) == 0:
             raise RuntimeError(
                 f"Cannot import lookup list {path}, did not find "
@@ -135,7 +134,6 @@ def validate_lookup_struct_cache(
     src_path = base_path / _SRC_SUBDIR
 
     for file in src_path.glob("**"):
-
         if datetime.fromtimestamp(os.stat(file).st_mtime) > datetime.fromisoformat(
             cache["saved_datetime"]
         ):
@@ -145,21 +143,21 @@ def validate_lookup_struct_cache(
 
 
 def load_lookup_structs_from_cache(
-    base_path: Path, deduce_version: str
+    cache_path: Path, deduce_version: str
 ) -> Optional[dd.ds.DsCollection]:
     """
     Loads lookup struct data from cache. Returns None when no cache is present, or when
     it's invalid.
 
     Args:
-        base_path: The base path where to look for the cache.
+        cache_base_path: The base path where to look for the cache.
         deduce_version: The current deduce version, used to validate.
 
     Returns:
         A DsCollection if present and valid, None otherwise.
     """
 
-    cache_file = base_path / _CACHE_SUBDIR / _CACHE_FILE
+    cache_file = cache_path / _CACHE_SUBDIR / _CACHE_FILE
 
     try:
         with open(cache_file, "rb") as file:
@@ -168,7 +166,7 @@ def load_lookup_structs_from_cache(
         return None
 
     if validate_lookup_struct_cache(
-        cache=cache, base_path=base_path, deduce_version=deduce_version
+        cache=cache, base_path=cache_path, deduce_version=deduce_version
     ):
         return cache["lookup_structs"]
 
@@ -176,18 +174,18 @@ def load_lookup_structs_from_cache(
 
 
 def cache_lookup_structs(
-    lookup_structs: dd.ds.DsCollection, base_path: Path, deduce_version: str
+    lookup_structs: dd.ds.DsCollection, cache_path: Path, deduce_version: str
 ) -> None:
     """
     Saves lookup structs to cache, along with some metadata.
 
     Args:
         lookup_structs: The lookup structures to cache.
-        base_path: The base path for lookup structures.
+        cache_base_path: The base path for lookup structures.
         deduce_version: The current deduce version.
     """
 
-    cache_file = base_path / _CACHE_SUBDIR / _CACHE_FILE
+    cache_file = cache_path / _CACHE_SUBDIR / _CACHE_FILE
 
     cache = {
         "deduce_version": deduce_version,
@@ -201,6 +199,7 @@ def cache_lookup_structs(
 
 def get_lookup_structs(
     lookup_path: Path,
+    cache_path: Path,
     tokenizer: Tokenizer,
     deduce_version: str,
     build: bool = False,
@@ -210,6 +209,7 @@ def get_lookup_structs(
     Loads all lookup structures, and handles caching.
     Args:
         lookup_path: The base path for lookup sets.
+        case_base_path: The base path for the cache.
         tokenizer: The tokenizer, used to create sequences for LookupTrie
         deduce_version: The current deduce version, used to validate cache.
         build: Whether to do a full build, even when cache is present and valid.
@@ -220,8 +220,9 @@ def get_lookup_structs(
     """
 
     if not build:
-
-        lookup_structs = load_lookup_structs_from_cache(lookup_path, deduce_version)
+        lookup_structs = load_lookup_structs_from_cache(
+            cache_path=cache_path, deduce_version=deduce_version
+        )
 
         if lookup_structs is not None:
             return lookup_structs
@@ -257,7 +258,7 @@ def get_lookup_structs(
     if save_cache:
         cache_lookup_structs(
             lookup_structs=lookup_structs,
-            base_path=lookup_path,
+            cache_path=cache_path,
             deduce_version=deduce_version,
         )
 

--- a/deduce/lookup_structs.py
+++ b/deduce/lookup_structs.py
@@ -185,13 +185,17 @@ def cache_lookup_structs(
         deduce_version: The current deduce version.
     """
 
-    cache_file = cache_path / _CACHE_SUBDIR / _CACHE_FILE
+    cache_path = cache_path / _CACHE_SUBDIR
+    cache_file = cache_path / _CACHE_FILE
 
     cache = {
         "deduce_version": deduce_version,
         "saved_datetime": str(datetime.now()),
         "lookup_structs": lookup_structs,
     }
+
+    if not cache_path.exists():
+        os.makedirs(cache_path)
 
     with open(cache_file, "wb") as file:
         pickle.dump(cache, file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "deduce"
-version = "3.0.2"
+version = "3.0.3"
 description = "Deduce: de-identification method for Dutch medical text"
 authors = ["Vincent Menger <vmenger@protonmail.com>"]
 maintainers = ["Vincent Menger <vmenger@protonmail.com>"]

--- a/tests/unit/test_lookup_struct.py
+++ b/tests/unit/test_lookup_struct.py
@@ -17,7 +17,6 @@ DATA_PATH = Path(".").cwd() / "tests" / "data" / "lookup"
 
 class TestLookupStruct:
     def test_load_raw_itemset(self):
-
         raw_itemset = load_raw_itemset(DATA_PATH / "src" / "lst_test")
 
         assert len(raw_itemset) == 5
@@ -29,13 +28,11 @@ class TestLookupStruct:
         assert "Wolter" not in raw_itemset
 
     def test_load_raw_itemset_nested(self):
-
         raw_itemset = load_raw_itemset(DATA_PATH / "src" / "lst_test_nested")
 
         assert raw_itemset == {"a", "b", "c", "d"}
 
     def test_load_raw_itemsets(self):
-
         raw_itemsets = load_raw_itemsets(
             base_path=DATA_PATH, subdirs=["lst_test", "lst_test_nested"]
         )
@@ -46,7 +43,6 @@ class TestLookupStruct:
         assert len(raw_itemsets["test_nested"]) == 4
 
     def test_validate_lookup_struct_cache_valid(self):
-
         cache = {
             "deduce_version": "2.5.0",
             "saved_datetime": "2023-12-06 10:19:39.198133",
@@ -63,7 +59,6 @@ class TestLookupStruct:
                 )
 
     def test_validate_lookup_struct_cache_file_changes(self):
-
         cache = {
             "deduce_version": "2.5.0",
             "saved_datetime": "2023-12-06 10:19:39.198133",
@@ -81,9 +76,8 @@ class TestLookupStruct:
 
     @patch("deduce.lookup_structs.validate_lookup_struct_cache", return_value=True)
     def test_load_lookup_structs_from_cache(self, _):
-
         ds_collection = load_lookup_structs_from_cache(
-            base_path=DATA_PATH, deduce_version="_"
+            cache_path=DATA_PATH, deduce_version="_"
         )
 
         assert len(ds_collection) == 2
@@ -92,18 +86,16 @@ class TestLookupStruct:
 
     @patch("deduce.lookup_structs.validate_lookup_struct_cache", return_value=True)
     def test_load_lookup_structs_from_cache_nofile(self, _):
-
         ds_collection = load_lookup_structs_from_cache(
-            base_path=DATA_PATH / "non_existing_dir", deduce_version="_"
+            cache_path=DATA_PATH / "non_existing_dir", deduce_version="_"
         )
 
         assert ds_collection is None
 
     @patch("deduce.lookup_structs.validate_lookup_struct_cache", return_value=False)
     def test_load_lookup_structs_from_cache_invalid(self, _):
-
         ds_collection = load_lookup_structs_from_cache(
-            base_path=DATA_PATH, deduce_version="_"
+            cache_path=DATA_PATH, deduce_version="_"
         )
 
         assert ds_collection is None
@@ -111,10 +103,9 @@ class TestLookupStruct:
     @patch("builtins.open", return_value=io.BytesIO())
     @patch("pickle.dump")
     def test_cache_lookup_structs(self, _, mock_pickle_dump):
-
         cache_lookup_structs(
             lookup_structs=dd.ds.DsCollection(),
-            base_path=DATA_PATH,
+            cache_path=DATA_PATH,
             deduce_version="2.5.0",
         )
 


### PR DESCRIPTION
- A cache_path option, to define the path for saving/loading the lookup structure cache. You should use this if your install directory is not writable.
